### PR TITLE
fix use of DEPENDS to include eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(eigen_stl_containers)
 
 find_package(catkin REQUIRED)
+
+# we don't build anything here, but in order to export the right
+# build flags in catkin_package(), we still have to find Eigen3 here
+find_package(Eigen3 REQUIRED)
+
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS Eigen)
+  DEPENDS EIGEN3)
 
 install(DIRECTORY include/
         DESTINATION include

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>eigen</build_depend>
   <run_depend>eigen</run_depend>
 
 </package>


### PR DESCRIPTION
This is the correct way to make use of catkin_package's DEPENDS
flag. It was plain broken before and I'm pretty sure nobody ever
checked.
